### PR TITLE
from monolithic build to matrix build.

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,22 @@
+<!--
+Thank you for contributing!
+Before you submit this PR we'd like to make sure you are aware of our technical requirements and best practices:
+
+* https://github.com/Pandemonium1986/.github/blob/main/CONTRIBUTING.md#coding-conventions
+-->
+
+**Describe the change**
+<!-- A clear and concise description of what the pull request is. -->
+
+**Testing**
+<!-- In case a feature was added, how were tests performed? -->
+Check the pipelines of the different roles in the many repo
+- [ ] [helm](https://github.com/Pandemonium1986/ansible-role-helm/actions)
+- [ ] [k9s](https://github.com/Pandemonium1986/ansible-role-k9s/actions)
+- [ ] [kubectl](https://github.com/Pandemonium1986/ansible-role-kubectl/actions)
+- [ ] [kubctx](https://github.com/Pandemonium1986/ansible-role-kubctx/actions)
+- [ ] [minikube](https://github.com/Pandemonium1986/ansible-role-minikube/actions)
+
+
+**Additional information**
+<!-- Add any other information -->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -14,7 +14,7 @@ Check the pipelines of the different roles in the many repo
 - [ ] [helm](https://github.com/Pandemonium1986/ansible-role-helm/actions)
 - [ ] [k9s](https://github.com/Pandemonium1986/ansible-role-k9s/actions)
 - [ ] [kubectl](https://github.com/Pandemonium1986/ansible-role-kubectl/actions)
-- [ ] [kubctx](https://github.com/Pandemonium1986/ansible-role-kubctx/actions)
+- [ ] [kubectx](https://github.com/Pandemonium1986/ansible-role-kubectx/actions)
 - [ ] [minikube](https://github.com/Pandemonium1986/ansible-role-minikube/actions)
 
 

--- a/roles/helm/.github/workflows/molecule.yml
+++ b/roles/helm/.github/workflows/molecule.yml
@@ -12,9 +12,25 @@ on:
       - master
 
 jobs:
-  molecule:
-    name:                      "Molecule: Job"
+  lint:
+    name:                      "Molecule: lint"
     runs-on:                   ubuntu-latest
+    steps:
+      - name:                  "Init: Run checkout@v2"
+        uses:                  actions/checkout@v2
+      - name:                  "Ansible: Lint role"
+        uses:                  ansible/ansible-lint-action@master
+        with:
+          targets:             "./"
+  molecule:
+    name:                      "Molecule: test"
+    runs-on:                   ubuntu-latest
+    strategy:
+      fail-fast:               false
+      matrix:
+        DKR_IMAGE:
+          - "debian9"
+          - "debian10"
     container:
         image:                 ghcr.io/pandemonium1986/alpine312:latest
         volumes:
@@ -28,10 +44,6 @@ jobs:
     steps:
       - name:                  "Init: Run checkout@v2"
         uses:                  actions/checkout@v2
-      - name:                  "Ansible: Lint role"
-        uses:                  ansible/ansible-lint-action@master
-        with:
-          targets:             "./"
       - name:                  "Molecule: Create"
         run:                   molecule create
       - name:                  "Molecule: Converge"

--- a/roles/helm/.github/workflows/molecule.yml
+++ b/roles/helm/.github/workflows/molecule.yml
@@ -41,6 +41,8 @@ jobs:
           PY_COLORS:           "1"
         options:               >-
           --workdir /opt/workspace/${{ github.repository }}
+    needs:
+      - lint
     steps:
       - name:                  "Init: Run checkout@v2"
         uses:                  actions/checkout@v2

--- a/roles/helm/.github/workflows/molecule.yml
+++ b/roles/helm/.github/workflows/molecule.yml
@@ -28,7 +28,7 @@ jobs:
     strategy:
       fail-fast:               false
       matrix:
-        DKR_IMAGE:
+        images:
           - "debian9"
           - "debian10"
     container:
@@ -39,6 +39,7 @@ jobs:
         env:
           ANSIBLE_FORCE_COLOR: "1"
           PY_COLORS:           "1"
+          DKR_IMAGE:  ${{ matrix.images }}
         options:               >-
           --workdir /opt/workspace/${{ github.repository }}
     needs:

--- a/roles/helm/.github/workflows/molecule.yml
+++ b/roles/helm/.github/workflows/molecule.yml
@@ -1,5 +1,5 @@
 ---
-name:                      "Molecule: Github actions pipeline"
+name:                      "Molecule"
 on:
   schedule:
     - cron:                    "0 21 * * *"
@@ -13,7 +13,7 @@ on:
 
 jobs:
   lint:
-    name:                      "Molecule: lint"
+    name:                      "Ansible: lint"
     runs-on:                   ubuntu-latest
     steps:
       - name:                  "Init: Run checkout@v2"
@@ -29,8 +29,11 @@ jobs:
       fail-fast:               false
       matrix:
         images:
+          - "centos7"
+          - "centos8"
           - "debian9"
           - "debian10"
+          - "ubuntu1804"
     container:
         image:                 ghcr.io/pandemonium1986/alpine312:latest
         volumes:

--- a/roles/helm/.github/workflows/molecule.yml
+++ b/roles/helm/.github/workflows/molecule.yml
@@ -13,7 +13,7 @@ on:
 
 jobs:
   lint:
-    name:                      "Ansible: lint"
+    name:                      "Ansible: Lint"
     runs-on:                   ubuntu-latest
     steps:
       - name:                  "Init: Run checkout@v2"
@@ -23,7 +23,7 @@ jobs:
         with:
           targets:             "./"
   molecule:
-    name:                      "Molecule: test"
+    name:                      "Molecule: Test"
     runs-on:                   ubuntu-latest
     strategy:
       fail-fast:               false

--- a/roles/helm/molecule/default/molecule.yml
+++ b/roles/helm/molecule/default/molecule.yml
@@ -1,72 +1,36 @@
 ---
 dependency:
-  name:               galaxy
-  enabled:            false
-  # role-file:        requirements.yml
+  name:                      galaxy
+  enabled:                   false
+  # role-file:               requirements.yml
 driver:
-  name:               docker
-lint:                 |
+  name:                      docker
+lint:                        |
   set -e
   yamllint .
   ansible-lint
 platforms:
-  - name:             molecule-debian9
-    hostname:         debian9
-    image:            pandemonium1986/debian9:latest
-    pull:             true
-    pre_build_image:  true
-    tty:              true
-    override_command: false
+  - name:                    molecule-${DKR_IMAGE:-debian10}
+    hostname:                ${DKR_IMAGE:-debian10}
+    image:                   pandemonium1986/${DKR_IMAGE:-debian10}:latest
+    pull:                    true
+    pre_build_image:         true
+    tty:                     true
+    override_command:        false
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
-    privileged:       true
-  - name:             molecule-debian10
-    hostname:         debian10
-    image:            pandemonium1986/debian10:latest
-    pull:             true
-    pre_build_image:  true
-    tty:              true
-    override_command: false
-    volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:ro
-    privileged:       true
-  - name:             molecule-centos7
-    hostname:         centos7
-    image:            pandemonium1986/centos7:latest
-    pull:             true
-    pre_build_image:  true
-    tty:              true
-    override_command: false
-    volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:ro
-    privileged:       true
-  - name:             molecule-centos8
-    hostname:         centos8
-    image:            pandemonium1986/centos8:latest
-    pull:             true
-    pre_build_image:  true
-    tty:              true
-    override_command: false
-    volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:ro
-    privileged:       true
-  - name:             molecule-ubuntu1804
-    hostname:         ubuntu1804
-    image:            pandemonium1986/ubuntu1804:latest
-    pull:             true
-    pre_build_image:  true
-    tty:              true
-    override_command: false
-    volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:ro
-    privileged:       true
+    privileged:              true
 provisioner:
-  name:               ansible
-  lint:               |
+  name:                      ansible
+  lint:                      |
     set -e
     ansible-lint
+  config_options:
+    defaults:
+      stdout_callback:       yaml
+      bin_ansible_callbacks: true
 scenario:
-  name:               default
+  name:                      default
 verifier:
-  name:               ansible
-  enabled:            true
+  name:                      ansible
+  enabled:                   true

--- a/roles/k9s/.github/workflows/molecule.yml
+++ b/roles/k9s/.github/workflows/molecule.yml
@@ -1,5 +1,5 @@
 ---
-name:                      "Molecule: Github actions pipeline"
+name:                      "Molecule"
 on:
   schedule:
     - cron:                    "0 21 * * *"
@@ -12,9 +12,28 @@ on:
       - master
 
 jobs:
-  molecule:
-    name:                      "Molecule: Job"
+  lint:
+    name:                      "Ansible: Lint"
     runs-on:                   ubuntu-latest
+    steps:
+      - name:                  "Init: Run checkout@v2"
+        uses:                  actions/checkout@v2
+      - name:                  "Ansible: Lint role"
+        uses:                  ansible/ansible-lint-action@master
+        with:
+          targets:             "./"
+  molecule:
+    name:                      "Molecule: Test"
+    runs-on:                   ubuntu-latest
+    strategy:
+      fail-fast:               false
+      matrix:
+        images:
+          - "centos7"
+          - "centos8"
+          - "debian9"
+          - "debian10"
+          - "ubuntu1804"
     container:
         image:                 ghcr.io/pandemonium1986/alpine312:latest
         volumes:
@@ -23,15 +42,14 @@ jobs:
         env:
           ANSIBLE_FORCE_COLOR: "1"
           PY_COLORS:           "1"
+          DKR_IMAGE:  ${{ matrix.images }}
         options:               >-
           --workdir /opt/workspace/${{ github.repository }}
+    needs:
+      - lint
     steps:
       - name:                  "Init: Run checkout@v2"
         uses:                  actions/checkout@v2
-      - name:                  "Ansible: Lint role"
-        uses:                  ansible/ansible-lint-action@master
-        with:
-          targets:             "./"
       - name:                  "Molecule: Create"
         run:                   molecule create
       - name:                  "Molecule: Converge"

--- a/roles/k9s/molecule/default/molecule.yml
+++ b/roles/k9s/molecule/default/molecule.yml
@@ -1,72 +1,36 @@
 ---
 dependency:
-  name:               galaxy
-  enabled:            false
-  # role-file:        requirements.yml
+  name:                      galaxy
+  enabled:                   false
+  # role-file:               requirements.yml
 driver:
-  name:               docker
-lint:                 |
+  name:                      docker
+lint:                        |
   set -e
   yamllint .
   ansible-lint
 platforms:
-  - name:             molecule-debian9
-    hostname:         debian9
-    image:            pandemonium1986/debian9:latest
-    pull:             true
-    pre_build_image:  true
-    tty:              true
-    override_command: false
+  - name:                    molecule-${DKR_IMAGE:-debian10}
+    hostname:                ${DKR_IMAGE:-debian10}
+    image:                   pandemonium1986/${DKR_IMAGE:-debian10}:latest
+    pull:                    true
+    pre_build_image:         true
+    tty:                     true
+    override_command:        false
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
-    privileged:       true
-  - name:             molecule-debian10
-    hostname:         debian10
-    image:            pandemonium1986/debian10:latest
-    pull:             true
-    pre_build_image:  true
-    tty:              true
-    override_command: false
-    volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:ro
-    privileged:       true
-  - name:             molecule-centos7
-    hostname:         centos7
-    image:            pandemonium1986/centos7:latest
-    pull:             true
-    pre_build_image:  true
-    tty:              true
-    override_command: false
-    volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:ro
-    privileged:       true
-  - name:             molecule-centos8
-    hostname:         centos8
-    image:            pandemonium1986/centos8:latest
-    pull:             true
-    pre_build_image:  true
-    tty:              true
-    override_command: false
-    volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:ro
-    privileged:       true
-  - name:             molecule-ubuntu1804
-    hostname:         ubuntu1804
-    image:            pandemonium1986/ubuntu1804:latest
-    pull:             true
-    pre_build_image:  true
-    tty:              true
-    override_command: false
-    volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:ro
-    privileged:       true
+    privileged:              true
 provisioner:
-  name:               ansible
-  lint:               |
+  name:                      ansible
+  lint:                      |
     set -e
     ansible-lint
+  config_options:
+    defaults:
+      stdout_callback:       yaml
+      bin_ansible_callbacks: true
 scenario:
-  name:               default
+  name:                      default
 verifier:
-  name:               ansible
-  enabled:            true
+  name:                      ansible
+  enabled:                   true

--- a/roles/kubectl/.github/workflows/molecule.yml
+++ b/roles/kubectl/.github/workflows/molecule.yml
@@ -1,5 +1,5 @@
 ---
-name:                      "Molecule: Github actions pipeline"
+name:                      "Molecule"
 on:
   schedule:
     - cron:                    "0 21 * * *"
@@ -12,9 +12,28 @@ on:
       - master
 
 jobs:
-  molecule:
-    name:                      "Molecule: Job"
+  lint:
+    name:                      "Ansible: Lint"
     runs-on:                   ubuntu-latest
+    steps:
+      - name:                  "Init: Run checkout@v2"
+        uses:                  actions/checkout@v2
+      - name:                  "Ansible: Lint role"
+        uses:                  ansible/ansible-lint-action@master
+        with:
+          targets:             "./"
+  molecule:
+    name:                      "Molecule: Test"
+    runs-on:                   ubuntu-latest
+    strategy:
+      fail-fast:               false
+      matrix:
+        images:
+          - "centos7"
+          - "centos8"
+          - "debian9"
+          - "debian10"
+          - "ubuntu1804"
     container:
         image:                 ghcr.io/pandemonium1986/alpine312:latest
         volumes:
@@ -23,15 +42,14 @@ jobs:
         env:
           ANSIBLE_FORCE_COLOR: "1"
           PY_COLORS:           "1"
+          DKR_IMAGE:  ${{ matrix.images }}
         options:               >-
           --workdir /opt/workspace/${{ github.repository }}
+    needs:
+      - lint
     steps:
       - name:                  "Init: Run checkout@v2"
         uses:                  actions/checkout@v2
-      - name:                  "Ansible: Lint role"
-        uses:                  ansible/ansible-lint-action@master
-        with:
-          targets:             "./"
       - name:                  "Molecule: Create"
         run:                   molecule create
       - name:                  "Molecule: Converge"

--- a/roles/kubectl/molecule/default/molecule.yml
+++ b/roles/kubectl/molecule/default/molecule.yml
@@ -1,72 +1,36 @@
 ---
 dependency:
-  name:               galaxy
-  enabled:            false
-  # role-file:        requirements.yml
+  name:                      galaxy
+  enabled:                   false
+  # role-file:               requirements.yml
 driver:
-  name:               docker
-lint:                 |
+  name:                      docker
+lint:                        |
   set -e
   yamllint .
   ansible-lint
 platforms:
-  - name:             molecule-debian9
-    hostname:         debian9
-    image:            pandemonium1986/debian9:latest
-    pull:             true
-    pre_build_image:  true
-    tty:              true
-    override_command: false
+  - name:                    molecule-${DKR_IMAGE:-debian10}
+    hostname:                ${DKR_IMAGE:-debian10}
+    image:                   pandemonium1986/${DKR_IMAGE:-debian10}:latest
+    pull:                    true
+    pre_build_image:         true
+    tty:                     true
+    override_command:        false
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
-    privileged:       true
-  - name:             molecule-debian10
-    hostname:         debian10
-    image:            pandemonium1986/debian10:latest
-    pull:             true
-    pre_build_image:  true
-    tty:              true
-    override_command: false
-    volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:ro
-    privileged:       true
-  - name:             molecule-centos7
-    hostname:         centos7
-    image:            pandemonium1986/centos7:latest
-    pull:             true
-    pre_build_image:  true
-    tty:              true
-    override_command: false
-    volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:ro
-    privileged:       true
-  - name:             molecule-centos8
-    hostname:         centos8
-    image:            pandemonium1986/centos8:latest
-    pull:             true
-    pre_build_image:  true
-    tty:              true
-    override_command: false
-    volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:ro
-    privileged:       true
-  - name:             molecule-ubuntu1804
-    hostname:         ubuntu1804
-    image:            pandemonium1986/ubuntu1804:latest
-    pull:             true
-    pre_build_image:  true
-    tty:              true
-    override_command: false
-    volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:ro
-    privileged:       true
+    privileged:              true
 provisioner:
-  name:               ansible
-  lint:               |
+  name:                      ansible
+  lint:                      |
     set -e
     ansible-lint
+  config_options:
+    defaults:
+      stdout_callback:       yaml
+      bin_ansible_callbacks: true
 scenario:
-  name:               default
+  name:                      default
 verifier:
-  name:               ansible
-  enabled:            true
+  name:                      ansible
+  enabled:                   true

--- a/roles/kubectx/.github/workflows/molecule.yml
+++ b/roles/kubectx/.github/workflows/molecule.yml
@@ -1,5 +1,5 @@
 ---
-name:                      "Molecule: Github actions pipeline"
+name:                      "Molecule"
 on:
   schedule:
     - cron:                    "0 21 * * *"
@@ -12,9 +12,28 @@ on:
       - master
 
 jobs:
-  molecule:
-    name:                      "Molecule: Job"
+  lint:
+    name:                      "Ansible: Lint"
     runs-on:                   ubuntu-latest
+    steps:
+      - name:                  "Init: Run checkout@v2"
+        uses:                  actions/checkout@v2
+      - name:                  "Ansible: Lint role"
+        uses:                  ansible/ansible-lint-action@master
+        with:
+          targets:             "./"
+  molecule:
+    name:                      "Molecule: Test"
+    runs-on:                   ubuntu-latest
+    strategy:
+      fail-fast:               false
+      matrix:
+        images:
+          - "centos7"
+          - "centos8"
+          - "debian9"
+          - "debian10"
+          - "ubuntu1804"
     container:
         image:                 ghcr.io/pandemonium1986/alpine312:latest
         volumes:
@@ -23,22 +42,14 @@ jobs:
         env:
           ANSIBLE_FORCE_COLOR: "1"
           PY_COLORS:           "1"
+          DKR_IMAGE:  ${{ matrix.images }}
         options:               >-
           --workdir /opt/workspace/${{ github.repository }}
+    needs:
+      - lint
     steps:
       - name:                  "Init: Run checkout@v2"
         uses:                  actions/checkout@v2
-      - name:                  "Ansible: Lint role"
-        uses:                  ansible/ansible-lint-action@master
-        with:
-          targets:             "./"
-      - name:                  Here is the death fix 😱
-        run:                   sed -i s/kubectl/pandemonium1986\.kubectl/g ./meta/main.yml
-      - name:                  Debug variables
-        run:                   |
-          echo ${{ github.workspace }}
-          ls -l ./
-          cat ./meta/main.yml
       - name:                  "Molecule: Create"
         run:                   molecule create
       - name:                  "Molecule: Converge"

--- a/roles/kubectx/.github/workflows/molecule.yml
+++ b/roles/kubectx/.github/workflows/molecule.yml
@@ -50,6 +50,13 @@ jobs:
     steps:
       - name:                  "Init: Run checkout@v2"
         uses:                  actions/checkout@v2
+      - name:                  Here is the death fix 😱
+        run:                   sed -i s/kubectl/pandemonium1986\.kubectl/g ./meta/main.yml
+      - name:                  Debug variables
+        run:                   |
+          echo ${{ github.workspace }}
+          ls -l ./
+          cat ./meta/main.yml
       - name:                  "Molecule: Create"
         run:                   molecule create
       - name:                  "Molecule: Converge"

--- a/roles/kubectx/molecule/default/molecule.yml
+++ b/roles/kubectx/molecule/default/molecule.yml
@@ -1,8 +1,8 @@
 ---
 dependency:
   name:                      galaxy
-  enabled:                   false
-  # role-file:               requirements.yml
+  enabled:                   true
+  role-file:                 requirements.yml
 driver:
   name:                      docker
 lint:                        |

--- a/roles/kubectx/molecule/default/molecule.yml
+++ b/roles/kubectx/molecule/default/molecule.yml
@@ -1,72 +1,36 @@
 ---
 dependency:
-  name:               galaxy
-  enabled:            true
-  role-file:          requirements.yml
+  name:                      galaxy
+  enabled:                   false
+  # role-file:               requirements.yml
 driver:
-  name:               docker
-lint:                 |
+  name:                      docker
+lint:                        |
   set -e
   yamllint .
   ansible-lint
 platforms:
-  - name:             molecule-debian9
-    hostname:         debian9
-    image:            pandemonium1986/debian9:latest
-    pull:             true
-    pre_build_image:  true
-    tty:              true
-    override_command: false
+  - name:                    molecule-${DKR_IMAGE:-debian10}
+    hostname:                ${DKR_IMAGE:-debian10}
+    image:                   pandemonium1986/${DKR_IMAGE:-debian10}:latest
+    pull:                    true
+    pre_build_image:         true
+    tty:                     true
+    override_command:        false
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
-    privileged:       true
-  - name:             molecule-debian10
-    hostname:         debian10
-    image:            pandemonium1986/debian10:latest
-    pull:             true
-    pre_build_image:  true
-    tty:              true
-    override_command: false
-    volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:ro
-    privileged:       true
-  - name:             molecule-centos7
-    hostname:         centos7
-    image:            pandemonium1986/centos7:latest
-    pull:             true
-    pre_build_image:  true
-    tty:              true
-    override_command: false
-    volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:ro
-    privileged:       true
-  - name:             molecule-centos8
-    hostname:         centos8
-    image:            pandemonium1986/centos8:latest
-    pull:             true
-    pre_build_image:  true
-    tty:              true
-    override_command: false
-    volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:ro
-    privileged:       true
-  - name:             molecule-ubuntu1804
-    hostname:         ubuntu1804
-    image:            pandemonium1986/ubuntu1804:latest
-    pull:             true
-    pre_build_image:  true
-    tty:              true
-    override_command: false
-    volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:ro
-    privileged:       true
+    privileged:              true
 provisioner:
-  name:               ansible
-  lint:               |
+  name:                      ansible
+  lint:                      |
     set -e
     ansible-lint
+  config_options:
+    defaults:
+      stdout_callback:       yaml
+      bin_ansible_callbacks: true
 scenario:
-  name:               default
+  name:                      default
 verifier:
-  name:               ansible
-  enabled:            true
+  name:                      ansible
+  enabled:                   true

--- a/roles/minikube/.github/workflows/molecule.yml
+++ b/roles/minikube/.github/workflows/molecule.yml
@@ -1,5 +1,5 @@
 ---
-name:                      "Molecule: Github actions pipeline"
+name:                      "Molecule"
 on:
   schedule:
     - cron:                    "0 21 * * *"
@@ -12,9 +12,28 @@ on:
       - master
 
 jobs:
-  molecule:
-    name:                      "Molecule: Job"
+  lint:
+    name:                      "Ansible: Lint"
     runs-on:                   ubuntu-latest
+    steps:
+      - name:                  "Init: Run checkout@v2"
+        uses:                  actions/checkout@v2
+      - name:                  "Ansible: Lint role"
+        uses:                  ansible/ansible-lint-action@master
+        with:
+          targets:             "./"
+  molecule:
+    name:                      "Molecule: Test"
+    runs-on:                   ubuntu-latest
+    strategy:
+      fail-fast:               false
+      matrix:
+        images:
+          - "centos7"
+          - "centos8"
+          - "debian9"
+          - "debian10"
+          - "ubuntu1804"
     container:
         image:                 ghcr.io/pandemonium1986/alpine312:latest
         volumes:
@@ -23,15 +42,14 @@ jobs:
         env:
           ANSIBLE_FORCE_COLOR: "1"
           PY_COLORS:           "1"
+          DKR_IMAGE:  ${{ matrix.images }}
         options:               >-
           --workdir /opt/workspace/${{ github.repository }}
+    needs:
+      - lint
     steps:
       - name:                  "Init: Run checkout@v2"
         uses:                  actions/checkout@v2
-      - name:                  "Ansible: Lint role"
-        uses:                  ansible/ansible-lint-action@master
-        with:
-          targets:             "./"
       - name:                  "Molecule: Create"
         run:                   molecule create
       - name:                  "Molecule: Converge"

--- a/roles/minikube/molecule/default/molecule.yml
+++ b/roles/minikube/molecule/default/molecule.yml
@@ -1,72 +1,36 @@
 ---
 dependency:
-  name:               galaxy
-  enabled:            false
-  # role-file:        requirements.yml
+  name:                      galaxy
+  enabled:                   false
+  # role-file:               requirements.yml
 driver:
-  name:               docker
-lint:                 |
+  name:                      docker
+lint:                        |
   set -e
   yamllint .
   ansible-lint
 platforms:
-  - name:             molecule-debian9
-    hostname:         debian9
-    image:            pandemonium1986/debian9:latest
-    pull:             true
-    pre_build_image:  true
-    tty:              true
-    override_command: false
+  - name:                    molecule-${DKR_IMAGE:-debian10}
+    hostname:                ${DKR_IMAGE:-debian10}
+    image:                   pandemonium1986/${DKR_IMAGE:-debian10}:latest
+    pull:                    true
+    pre_build_image:         true
+    tty:                     true
+    override_command:        false
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
-    privileged:       true
-  - name:             molecule-debian10
-    hostname:         debian10
-    image:            pandemonium1986/debian10:latest
-    pull:             true
-    pre_build_image:  true
-    tty:              true
-    override_command: false
-    volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:ro
-    privileged:       true
-  - name:             molecule-centos7
-    hostname:         centos7
-    image:            pandemonium1986/centos7:latest
-    pull:             true
-    pre_build_image:  true
-    tty:              true
-    override_command: false
-    volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:ro
-    privileged:       true
-  - name:             molecule-centos8
-    hostname:         centos8
-    image:            pandemonium1986/centos8:latest
-    pull:             true
-    pre_build_image:  true
-    tty:              true
-    override_command: false
-    volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:ro
-    privileged:       true
-  - name:             molecule-ubuntu1804
-    hostname:         ubuntu1804
-    image:            pandemonium1986/ubuntu1804:latest
-    pull:             true
-    pre_build_image:  true
-    tty:              true
-    override_command: false
-    volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:ro
-    privileged:       true
+    privileged:              true
 provisioner:
-  name:               ansible
-  lint:               |
+  name:                      ansible
+  lint:                      |
     set -e
     ansible-lint
+  config_options:
+    defaults:
+      stdout_callback:       yaml
+      bin_ansible_callbacks: true
 scenario:
-  name:               default
+  name:                      default
 verifier:
-  name:               ansible
-  enabled:            true
+  name:                      ansible
+  enabled:                   true

--- a/roles/stern/.github/workflows/molecule.yml
+++ b/roles/stern/.github/workflows/molecule.yml
@@ -1,5 +1,5 @@
 ---
-name:                      "Molecule: Github actions pipeline"
+name:                      "Molecule"
 on:
   schedule:
     - cron:                    "0 21 * * *"
@@ -12,9 +12,28 @@ on:
       - master
 
 jobs:
-  molecule:
-    name:                      "Molecule: Job"
+  lint:
+    name:                      "Ansible: Lint"
     runs-on:                   ubuntu-latest
+    steps:
+      - name:                  "Init: Run checkout@v2"
+        uses:                  actions/checkout@v2
+      - name:                  "Ansible: Lint role"
+        uses:                  ansible/ansible-lint-action@master
+        with:
+          targets:             "./"
+  molecule:
+    name:                      "Molecule: Test"
+    runs-on:                   ubuntu-latest
+    strategy:
+      fail-fast:               false
+      matrix:
+        images:
+          - "centos7"
+          - "centos8"
+          - "debian9"
+          - "debian10"
+          - "ubuntu1804"
     container:
         image:                 ghcr.io/pandemonium1986/alpine312:latest
         volumes:
@@ -23,15 +42,14 @@ jobs:
         env:
           ANSIBLE_FORCE_COLOR: "1"
           PY_COLORS:           "1"
+          DKR_IMAGE:  ${{ matrix.images }}
         options:               >-
           --workdir /opt/workspace/${{ github.repository }}
+    needs:
+      - lint
     steps:
       - name:                  "Init: Run checkout@v2"
         uses:                  actions/checkout@v2
-      - name:                  "Ansible: Lint role"
-        uses:                  ansible/ansible-lint-action@master
-        with:
-          targets:             "./"
       - name:                  "Molecule: Create"
         run:                   molecule create
       - name:                  "Molecule: Converge"

--- a/roles/stern/molecule/default/molecule.yml
+++ b/roles/stern/molecule/default/molecule.yml
@@ -1,72 +1,36 @@
 ---
 dependency:
-  name:               galaxy
-  enabled:            false
-  # role-file:        requirements.yml
+  name:                      galaxy
+  enabled:                   false
+  # role-file:               requirements.yml
 driver:
-  name:               docker
-lint:                 |
+  name:                      docker
+lint:                        |
   set -e
   yamllint .
   ansible-lint
 platforms:
-  - name:             molecule-debian9
-    hostname:         debian9
-    image:            pandemonium1986/debian9:latest
-    pull:             true
-    pre_build_image:  true
-    tty:              true
-    override_command: false
+  - name:                    molecule-${DKR_IMAGE:-debian10}
+    hostname:                ${DKR_IMAGE:-debian10}
+    image:                   pandemonium1986/${DKR_IMAGE:-debian10}:latest
+    pull:                    true
+    pre_build_image:         true
+    tty:                     true
+    override_command:        false
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
-    privileged:       true
-  - name:             molecule-debian10
-    hostname:         debian10
-    image:            pandemonium1986/debian10:latest
-    pull:             true
-    pre_build_image:  true
-    tty:              true
-    override_command: false
-    volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:ro
-    privileged:       true
-  - name:             molecule-centos7
-    hostname:         centos7
-    image:            pandemonium1986/centos7:latest
-    pull:             true
-    pre_build_image:  true
-    tty:              true
-    override_command: false
-    volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:ro
-    privileged:       true
-  - name:             molecule-centos8
-    hostname:         centos8
-    image:            pandemonium1986/centos8:latest
-    pull:             true
-    pre_build_image:  true
-    tty:              true
-    override_command: false
-    volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:ro
-    privileged:       true
-  - name:             molecule-ubuntu1804
-    hostname:         ubuntu1804
-    image:            pandemonium1986/ubuntu1804:latest
-    pull:             true
-    pre_build_image:  true
-    tty:              true
-    override_command: false
-    volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:ro
-    privileged:       true
+    privileged:              true
 provisioner:
-  name:               ansible
-  lint:               |
+  name:                      ansible
+  lint:                      |
     set -e
     ansible-lint
+  config_options:
+    defaults:
+      stdout_callback:       yaml
+      bin_ansible_callbacks: true
 scenario:
-  name:               default
+  name:                      default
 verifier:
-  name:               ansible
-  enabled:            true
+  name:                      ansible
+  enabled:                   true


### PR DESCRIPTION
**Describe the change**
Refactor github actions workflows from a monolithic build to a matrix build.

**Testing**
Check the pipelines of the different roles in the many repo
- [x] [helm](https://github.com/Pandemonium1986/ansible-role-helm/actions)
- [x] [k9s](https://github.com/Pandemonium1986/ansible-role-k9s/actions)
- [x] [kubectl](https://github.com/Pandemonium1986/ansible-role-kubectl/actions)
- [x] [kubectx](https://github.com/Pandemonium1986/ansible-role-kubectx/actions)
- [x] [minikube](https://github.com/Pandemonium1986/ansible-role-minikube/actions)


**Additional information**
Use molecule variable substitution
