### PR TITLE
chore(deps): bump k9s from v0.24.7 to v0.24.8

### DIFF
--- a/roles/k9s/defaults/main.yml
+++ b/roles/k9s/defaults/main.yml
@@ -2,5 +2,5 @@
 # https://github.com/derailed/k9s
 k9s_cache_path:        "/var/cache/github"
 k9s_installation_path: "/opt/github/k9s"
-k9s_checksum:          "sha256:5096820f8c55708b059c3a01c5baeecca210c6b955740419d6b30b3132589619"
-k9s_version:           "v0.24.7"
+k9s_checksum:          "sha256:9a57de7b65c3b7be315e2a187c515fee72245f8ef789de5eb7cca2b7e2e2d158"
+k9s_version:           "v0.24.8"


### PR DESCRIPTION
<!--
Thank you for contributing!
Before you submit this PR we'd like to make sure you are aware of our technical requirements and best practices:

* https://github.com/Pandemonium1986/.github/blob/main/CONTRIBUTING.md#coding-conventions
-->

**Describe the change**
* chore(deps): bump  k9s

**Testing**
<!-- In case a feature was added, how were tests performed? -->
Check the pipelines of the different roles in the many repo
- [x] [helm](https://github.com/Pandemonium1986/ansible-role-helm/actions)
- [x] [k9s](https://github.com/Pandemonium1986/ansible-role-k9s/actions)
- [x] [kubectl](https://github.com/Pandemonium1986/ansible-role-kubectl/actions)
- [x] [kubectx](https://github.com/Pandemonium1986/ansible-role-kubectx/actions)
- [x] [minikube](https://github.com/Pandemonium1986/ansible-role-minikube/actions)


**Additional information**
<!-- Add any other information -->
